### PR TITLE
add:ユーザーごとの頻出カテゴリを算出するロジックを実装する

### DIFF
--- a/src/backend/data_loader/load_dataset.py
+++ b/src/backend/data_loader/load_dataset.py
@@ -1,11 +1,8 @@
 import pandas as pd
 
 DATA_DIR = "data/"
-
-
-def read_spend_dataset(data_dir: str, file_name: str):
-    df = pd.read_csv(f"{data_dir}{file_name}")
-    return df[df["amount"] < 0]
+TRANSACTION_COLS = ["account_id", "category_id", "date", "amount", "balance_as_of"]
+CATEGORY_COLS = ["id", "name_ja", "category_type"]
 
 
 def extract_latest_month(df: pd.DataFrame):
@@ -16,5 +13,27 @@ def extract_latest_month(df: pd.DataFrame):
     return df
 
 
-df = read_spend_dataset(DATA_DIR, "取引明細_transactions.csv")
-print(extract_latest_month(df))
+def merge_category_id(
+    spend_df: pd.DataFrame, category_df: pd.DataFrame, left_col: str, right_col: str
+):
+    return pd.merge(
+        spend_df, category_df, left_on=left_col, right_on=right_col, how="inner"
+    )
+
+
+def main(
+    file_path: str,
+    category_df_path: str,
+    category_col_for_transaction_df: str,
+    category_col_for_category_df: str,
+):
+    transaction_df = extract_latest_month(pd.read_csv(DATA_DIR + file_path))[
+        TRANSACTION_COLS
+    ]
+    spend_df = transaction_df[transaction_df["amount"] < 0]
+    return merge_category_id(
+        spend_df,
+        pd.read_csv(DATA_DIR + category_df_path)[CATEGORY_COLS],
+        category_col_for_transaction_df,
+        category_col_for_category_df,
+    )

--- a/src/backend/features/get_frequent_category.py
+++ b/src/backend/features/get_frequent_category.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path().absolute()))
+from src.backend.data_loader import load_dataset
+
+
+df = load_dataset.main(
+    "取引明細_transactions.csv", "カテゴリマスタ_categories.csv", "category_id", "id"
+)
+
+# TODO: 「カード返済」「ATM引き出し」「振替」「振込手数料」「手数料」など特定カテゴリを排除する
+# TODO: 消費カテゴリごとの重み付けを行う
+# TODO: カテゴリを算出する月を限定する？（最新月など）
+# TODO: カテゴリがないuserに対しては、どのようにカテゴリ付与するのか考える
+
+
+def get_frequent_category(df: pd.DataFrame, account_id_col: str, category_col: str):
+    grouped = (
+        df.groupby([account_id_col, category_col]).size().reset_index(name="counts")
+    )
+    return grouped.sort_values("counts", ascending=False).drop_duplicates(
+        account_id_col
+    )
+
+
+frequent_category = get_frequent_category(df, "account_id", "name_ja")
+print(frequent_category.value_counts("name_ja"))


### PR DESCRIPTION
# 目的・概要
コンテンツベースのレコメンドを実装したい
- ユーザの興味カテゴリを算出して、コンテンツのカテゴリと突合する必要がある
- ユーザ毎の頻出消費カテゴリを算出するロジックを実装する

# チケット・参考リンク
なし

# 変更内容
- データセットの読み込み関数を実装
- ユーザーごとの頻出カテゴリを算出するロジックを実装

# 動作確認（確認方法とプロセスを明確に記載する）

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
