### PR TITLE
refecter:GPT-4-Visionスクリプトにサンプルデータを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv/
 .env
 data/
+*pyc

--- a/src/backend/features/gpt_4_vision.py
+++ b/src/backend/features/gpt_4_vision.py
@@ -96,7 +96,9 @@ def get_ad_category(
 application_json = {
     "タイトル": "「究極の可愛さ！フルーツパラダイス」",
     "CTAテキスト": "「今すぐ遊んでみよう！」",
-    "画像説明": detect_gpt_4_vision(encode_image("data/ad_image/application.png"), "png"),
+    "画像説明": detect_gpt_4_vision(
+        encode_image("data/ad_image/application.png"), "png"
+    ),
 }
 
 category_list = [
@@ -115,9 +117,30 @@ category_list = [
     "インターネット",
     "WEBサービス",
     "ゲーム",
+    "飲食",
 ]
 
-res = get_ad_category("data/ad_image/application.png", application_json, category_list)
+book_json = {
+    "タイトル": "「今宵のお楽しみ」",
+    "CTAテキスト": "キャンペーンをチェック！",
+    "画像説明": detect_gpt_4_vision(encode_image("data/ad_image/book.png"), "png"),
+}
 
-print(application_json)
+chocolate_json = {
+    "タイトル": "「感性を刺激する、上質なチョコレート体験」",
+    "CTAテキスト": "今すぐ味わう",
+    "画像説明": detect_gpt_4_vision(
+        encode_image("data/ad_image/chocolate.jpg"), "jpeg"
+    ),
+}
+
+hatomugi_json = {
+    "タイトル": "「肌悩みに革命を！独自成分で実現するクリアスキン」",
+    "CTAテキスト": "限定価格で購入する",
+    "画像説明": detect_gpt_4_vision(encode_image("data/ad_image/hatomugi.png"), "png"),
+}
+
+
+res = get_ad_category("data/ad_image/hatomugi.png", hatomugi_json, category_list)
+
 print(res)


### PR DESCRIPTION
# 目的・概要
- GPT-4-Visionのサンプルデータを追加したい
  - タイトル/CTAテキスト + 画像パスを渡すことで、自動タグ付けがされるようにする

# チケット・参考リンク
なし

# 変更内容
- gitignoreファイルの修正
- gpt-4-visionファイルにサンプルデータを追加
  - ハトムギ美容液
  - チョコレート

# 動作確認（確認方法とプロセスを明確に記載する）
- Pythonスクリプトのローカル実行
  - `cd path/to/root & python src/backend/features/gpt_4_vision.py`

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [x] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
