### PR TITLE
change:各ユーザーIDに対して、広告パスを一つレコメンドするアルゴリズムを実装

### DIFF
--- a/src/backend/data_loader/load_dataset.py
+++ b/src/backend/data_loader/load_dataset.py
@@ -5,7 +5,7 @@ TRANSACTION_COLS = ["account_id", "category_id", "date", "amount", "balance_as_o
 CATEGORY_COLS = ["id", "name_ja", "category_type"]
 
 
-def extract_latest_month(df: pd.DataFrame):
+def extract_latest_month(df: pd.DataFrame) -> pd.DataFrame:
     df["yyyymm"] = df["date"].str[:7].str.replace("-", "")
     df["date"] = df["date"].str[:10]
     df["date"] = pd.to_datetime(df["date"], format="%Y-%m-%d")
@@ -15,25 +15,7 @@ def extract_latest_month(df: pd.DataFrame):
 
 def merge_category_id(
     spend_df: pd.DataFrame, category_df: pd.DataFrame, left_col: str, right_col: str
-):
+) -> pd.DataFrame:
     return pd.merge(
         spend_df, category_df, left_on=left_col, right_on=right_col, how="inner"
-    )
-
-
-def main(
-    file_path: str,
-    category_df_path: str,
-    category_col_for_transaction_df: str,
-    category_col_for_category_df: str,
-):
-    transaction_df = extract_latest_month(pd.read_csv(DATA_DIR + file_path))[
-        TRANSACTION_COLS
-    ]
-    spend_df = transaction_df[transaction_df["amount"] < 0]
-    return merge_category_id(
-        spend_df,
-        pd.read_csv(DATA_DIR + category_df_path)[CATEGORY_COLS],
-        category_col_for_transaction_df,
-        category_col_for_category_df,
     )

--- a/src/backend/features/get_frequent_category.py
+++ b/src/backend/features/get_frequent_category.py
@@ -1,14 +1,4 @@
 import pandas as pd
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path().absolute()))
-from src.backend.data_loader import load_dataset
-
-
-df = load_dataset.main(
-    "取引明細_transactions.csv", "カテゴリマスタ_categories.csv", "category_id", "id"
-)
 
 # TODO: 「カード返済」「ATM引き出し」「振替」「振込手数料」「手数料」など特定カテゴリを排除する
 # TODO: 消費カテゴリごとの重み付けを行う
@@ -16,14 +6,12 @@ df = load_dataset.main(
 # TODO: カテゴリがないuserに対しては、どのようにカテゴリ付与するのか考える
 
 
-def get_frequent_category(df: pd.DataFrame, account_id_col: str, category_col: str):
+def get_frequent_category(
+    df: pd.DataFrame, account_id_col: str, category_col: str
+) -> pd.DataFrame:
     grouped = (
         df.groupby([account_id_col, category_col]).size().reset_index(name="counts")
     )
     return grouped.sort_values("counts", ascending=False).drop_duplicates(
         account_id_col
     )
-
-
-frequent_category = get_frequent_category(df, "account_id", "name_ja")
-print(frequent_category.value_counts("name_ja"))

--- a/src/backend/features/gpt_4_vision.py
+++ b/src/backend/features/gpt_4_vision.py
@@ -139,8 +139,3 @@ hatomugi_json = {
     "CTAテキスト": "限定価格で購入する",
     "画像説明": detect_gpt_4_vision(encode_image("data/ad_image/hatomugi.png"), "png"),
 }
-
-
-res = get_ad_category("data/ad_image/hatomugi.png", hatomugi_json, category_list)
-
-print(res)

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1,0 +1,64 @@
+import pandas as pd
+import random
+
+from data_loader.load_dataset import (
+    extract_latest_month,
+    merge_category_id,
+    DATA_DIR,
+    TRANSACTION_COLS,
+    CATEGORY_COLS,
+)
+from features.get_frequent_category import get_frequent_category
+
+ad_images_info = [
+    {"image_path": "data/ad_image/hatomugi.png", "category": "消耗品"},
+    {"image_path": "data/ad_image/hatomugi_2.png", "category": "消耗品"},
+    {"image_path": "data/ad_image/chocolate.png", "category": "飲食"},
+    {"image_path": "data/ad_image/application.png", "category": "ゲーム"},
+    {"image_path": "data/ad_image/lunch-box.png", "category": "コンビニ"},
+]
+
+ad_image_paths = {}
+for info in ad_images_info:
+    if info["category"] in ad_image_paths:
+        ad_image_paths[info["category"]].append(info["image_path"])
+    else:
+        ad_image_paths[info["category"]] = [info["image_path"]]
+"""
+{
+    "消耗品": ["data/ad_image/hatomugi.png", "data/ad_image/hatomugi_2.png"],
+    "飲食": ["data/ad_image/chocolate.png"],
+    "ゲーム": ["data/ad_image/application.png"],
+    "コンビニ": ["data/ad_image/lunch-box.png"],
+}
+"""
+
+
+def assign_ad_image_path(frequent_category: str):
+    if frequent_category in ad_image_paths:
+        return random.choice(ad_image_paths[frequent_category])
+    else:
+        all_images = [path for paths in ad_image_paths.values() for path in paths]
+        return random.choice(all_images)
+
+
+def main():
+    transaction_df = extract_latest_month(
+        pd.read_csv(DATA_DIR + "取引明細_transactions.csv")
+    )[TRANSACTION_COLS]
+    category_df = pd.read_csv(DATA_DIR + "カテゴリマスタ_categories.csv")[CATEGORY_COLS]
+    spend_df = transaction_df[transaction_df["amount"] < 0]
+    merged_df = merge_category_id(spend_df, category_df, "category_id", "id")
+
+    frequent_category_df = get_frequent_category(merged_df, "account_id", "name_ja")
+
+    frequent_category_df["ad_image_path"] = frequent_category_df["name_ja"].apply(
+        assign_ad_image_path
+    )
+    print(frequent_category_df[["account_id", "name_ja", "ad_image_path"]])
+
+    return frequent_category_df
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# 目的・概要
各ユーザーIDに対して、広告パスを一つレコメンドするようにしたい
- もしカテゴリに対する広告がなければ、ランダムで1つ選択する
- カテゴリに対して複数広告がある場合に、ランダムで1つの広告パスを選択する

# チケット・参考リンク
- なし

# 変更内容
- メインに移す処理は各ファイルから削除する
- メインファイルの実装
  - 画像ファイルのカテゴリを整形する
  - データを読み込んで、各ユーザーに頻出カテゴリを算出する
  - 頻出カテゴリに対して、広告パスを選択する

# 動作確認（確認方法とプロセスを明確に記載する）
- `cd path/to/root && python src/backend/main.py`

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [x] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
